### PR TITLE
Add pytest-asyncio plugin for async tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.pytest_cache/
+*.py[cod]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 pytest
+pytest-asyncio


### PR DESCRIPTION
## Summary
- install pytest-asyncio to run async tests
- ignore Python cache directories

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pytest-asyncio)*
- `pytest -q` *(fails: async def functions are not natively supported)*


------
https://chatgpt.com/codex/tasks/task_e_688eb60e10508323961bef39c47bbbab