### PR TITLE
fix: add pytest-asyncio dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 pytest
+pytest-asyncio


### PR DESCRIPTION
## Summary
- add pytest-asyncio to requirements to run async tests

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pytest-asyncio)*
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_688eb7a282dc8323a74c1bd944f87ece