### PR TITLE
Add courier enum and enforce allowed tracking values

### DIFF
--- a/app/api/tracking.py
+++ b/app/api/tracking.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends
 
 from app.services.tracking_service import TrackingService
 from app.data.response.tracking_response import TrackingResponse
+from app.data.domain.courier import Courier
 
 router = APIRouter(prefix="/api/v1")
 
@@ -12,5 +13,7 @@ async def health():
 
 
 @router.get("/shipments/{tracking_number}", response_model=TrackingResponse)
-async def get_tracking(tracking_number: str, courier: str, service: TrackingService = Depends()):
+async def get_tracking(
+    tracking_number: str, courier: Courier, service: TrackingService = Depends()
+):
     return await service.track(tracking_number, courier)

--- a/app/data/domain/courier.py
+++ b/app/data/domain/courier.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+
+class Courier(str, Enum):
+    STUB = "stub"

--- a/app/data/response/tracking_response.py
+++ b/app/data/response/tracking_response.py
@@ -4,6 +4,7 @@ from typing import List
 from pydantic import BaseModel
 
 from app.data.domain.tracking import TrackingStatus
+from app.data.domain.courier import Courier
 
 
 class TrackingEvent(BaseModel):
@@ -13,7 +14,7 @@ class TrackingEvent(BaseModel):
 
 class TrackingResponse(BaseModel):
     tracking_number: str
-    courier: str
+    courier: Courier
     status: TrackingStatus
     last_updated: datetime
     events: List[TrackingEvent] = []

--- a/app/services/providers/stub.py
+++ b/app/services/providers/stub.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from app.data.response.tracking_response import TrackingResponse, TrackingEvent
 from app.data.domain.tracking import TrackingStatus
+from app.data.domain.courier import Courier
 from .base import Provider
 
 
@@ -10,7 +11,7 @@ class StubProvider(Provider):
         event = TrackingEvent(description="Package received", timestamp=datetime.utcnow())
         return TrackingResponse(
             tracking_number=tracking_number,
-            courier="stub",
+            courier=Courier.STUB,
             status=TrackingStatus.IN_TRANSIT,
             last_updated=datetime.utcnow(),
             events=[event],

--- a/app/services/tracking_service.py
+++ b/app/services/tracking_service.py
@@ -1,12 +1,13 @@
 from app.data.response.tracking_response import TrackingResponse
 from app.services.providers.stub import StubProvider
+from app.data.domain.courier import Courier
 
 
 class TrackingService:
     def __init__(self):
-        self.providers = {"stub": StubProvider()}
+        self.providers = {Courier.STUB: StubProvider()}
 
-    async def track(self, tracking_number: str, courier: str) -> TrackingResponse:
+    async def track(self, tracking_number: str, courier: Courier) -> TrackingResponse:
         provider = self.providers.get(courier)
         if not provider:
             raise ValueError("unsupported courier")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 pytest
 pytest-asyncio
+httpx

--- a/tests/unit/test_tracking_api.py
+++ b/tests/unit/test_tracking_api.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_get_tracking_rejects_invalid_courier():
+    response = client.get("/api/v1/shipments/123", params={"courier": "invalid"})
+    assert response.status_code == 422
+
+
+def test_get_tracking_accepts_valid_courier():
+    response = client.get("/api/v1/shipments/123", params={"courier": "stub"})
+    assert response.status_code == 200
+    assert response.json()["courier"] == "stub"

--- a/tests/unit/test_tracking_service.py
+++ b/tests/unit/test_tracking_service.py
@@ -1,11 +1,12 @@
 import pytest
 
 from app.services.tracking_service import TrackingService
+from app.data.domain.courier import Courier
 
 
 @pytest.mark.asyncio
 async def test_stub_provider_tracks():
     service = TrackingService()
-    resp = await service.track("123", "stub")
+    resp = await service.track("123", Courier.STUB)
     assert resp.tracking_number == "123"
-    assert resp.courier == "stub"
+    assert resp.courier == Courier.STUB


### PR DESCRIPTION
## Summary
- add Courier enum for supported shipment providers
- require Courier enum in tracking API and service
- test API rejects unsupported courier values
