### PR TITLE
refactor: reuse persistent http client for Andreani provider

### DIFF
--- a/app/api/tracking.py
+++ b/app/api/tracking.py
@@ -4,6 +4,14 @@ from app.services.tracking_service import TrackingService
 from app.data.response.tracking_response import TrackingResponse
 from app.data.domain.courier import Courier
 
+
+async def get_tracking_service():
+    service = TrackingService()
+    try:
+        yield service
+    finally:
+        await service.aclose()
+
 router = APIRouter(prefix="/api/v1")
 
 
@@ -14,6 +22,8 @@ async def health():
 
 @router.get("/shipments/{tracking_number}", response_model=TrackingResponse)
 async def get_tracking(
-    tracking_number: str, courier: Courier, service: TrackingService = Depends()
+    tracking_number: str,
+    courier: Courier,
+    service: TrackingService = Depends(get_tracking_service),
 ):
     return await service.track(tracking_number, courier)

--- a/app/data/domain/courier.py
+++ b/app/data/domain/courier.py
@@ -3,3 +3,4 @@ from enum import Enum
 
 class Courier(str, Enum):
     STUB = "stub"
+    ANDREANI = "andreani"

--- a/app/services/providers/andreani.py
+++ b/app/services/providers/andreani.py
@@ -1,0 +1,63 @@
+import os
+from datetime import datetime
+from typing import List
+
+import httpx
+
+from app.data.domain.courier import Courier
+from app.data.domain.tracking import TrackingStatus
+from app.data.response.tracking_response import TrackingResponse, TrackingEvent
+from .base import Provider
+
+
+class AndreaniProvider(Provider):
+    """Provider implementation for Andreani courier."""
+
+    DEFAULT_BASE_URL = "https://apidestinatarios.andreani.com"
+
+    def __init__(self) -> None:
+        base_url = os.getenv("ANDREANI_BASE_URL", self.DEFAULT_BASE_URL)
+        timeout = httpx.Timeout(
+            connect=float(os.getenv("ANDREANI_CONNECT_TIMEOUT", "5")),
+            read=float(os.getenv("ANDREANI_READ_TIMEOUT", "10")),
+            write=float(os.getenv("ANDREANI_WRITE_TIMEOUT", "5")),
+            pool=float(os.getenv("ANDREANI_POOL_TIMEOUT", "5")),
+        )
+        self._client = httpx.AsyncClient(base_url=base_url, timeout=timeout)
+
+    async def track(self, tracking_number: str) -> TrackingResponse:
+        response = await self._client.get(f"/api/envios/{tracking_number}/trazas")
+        response.raise_for_status()
+        data = response.json()
+
+        events: List[TrackingEvent] = []
+        for item in data or []:
+            description = item["descripcion"]
+            timestamp_str = item["fecha"]
+            try:
+                timestamp = datetime.fromisoformat(timestamp_str)
+            except ValueError:
+                timestamp = datetime.utcnow()
+            events.append(TrackingEvent(description=description, timestamp=timestamp))
+
+        events.sort(key=lambda e: e.timestamp)
+
+        summary_desc = data[0]["estado"] if data else ""
+        status = (
+            TrackingStatus.DELIVERED
+            if summary_desc == "Entregado"
+            else TrackingStatus.IN_TRANSIT
+        )
+
+        last_updated = events[-1].timestamp if events else datetime.utcnow()
+
+        return TrackingResponse(
+            tracking_number=tracking_number,
+            courier=Courier.ANDREANI,
+            status=status,
+            last_updated=last_updated,
+            events=events,
+        )
+
+    async def aclose(self) -> None:
+        await self._client.aclose()

--- a/app/services/tracking_service.py
+++ b/app/services/tracking_service.py
@@ -1,14 +1,24 @@
 from app.data.response.tracking_response import TrackingResponse
 from app.services.providers.stub import StubProvider
+from app.services.providers.andreani import AndreaniProvider
 from app.data.domain.courier import Courier
 
 
 class TrackingService:
     def __init__(self):
-        self.providers = {Courier.STUB: StubProvider()}
+        self.providers = {
+            Courier.STUB: StubProvider(),
+            Courier.ANDREANI: AndreaniProvider(),
+        }
 
     async def track(self, tracking_number: str, courier: Courier) -> TrackingResponse:
         provider = self.providers.get(courier)
         if not provider:
             raise ValueError("unsupported courier")
         return await provider.track(tracking_number)
+
+    async def aclose(self) -> None:
+        for provider in self.providers.values():
+            close = getattr(provider, "aclose", None)
+            if close:
+                await close()

--- a/tests/unit/test_andreani_provider.py
+++ b/tests/unit/test_andreani_provider.py
@@ -1,0 +1,49 @@
+import httpx
+import pytest
+
+from app.services.providers.andreani import AndreaniProvider
+
+
+class DummyResponse:
+    def raise_for_status(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+    def json(self):  # pragma: no cover - simple stub
+        return []
+
+
+@pytest.mark.asyncio
+async def test_andreani_provider_uses_env_configuration(monkeypatch):
+    monkeypatch.setenv("ANDREANI_BASE_URL", "https://example.com")
+    monkeypatch.setenv("ANDREANI_CONNECT_TIMEOUT", "1")
+    monkeypatch.setenv("ANDREANI_READ_TIMEOUT", "2")
+    monkeypatch.setenv("ANDREANI_WRITE_TIMEOUT", "3")
+    monkeypatch.setenv("ANDREANI_POOL_TIMEOUT", "4")
+
+    captured = {}
+
+    class DummyAsyncClient:
+        def __init__(self, *args, **kwargs):
+            captured["base_url"] = str(kwargs.get("base_url"))
+            captured["timeout"] = kwargs.get("timeout")
+
+        async def get(self, url):
+            return DummyResponse()
+
+        async def aclose(self):
+            captured["closed"] = True
+
+    monkeypatch.setattr(httpx, "AsyncClient", DummyAsyncClient)
+
+    provider = AndreaniProvider()
+    await provider.track("CODE123")
+    await provider.aclose()
+
+    assert captured["base_url"] == "https://example.com"
+    timeout = captured["timeout"]
+    assert timeout.connect == 1.0
+    assert timeout.read == 2.0
+    assert timeout.write == 3.0
+    assert timeout.pool == 4.0
+    assert captured["closed"] is True
+

--- a/tests/unit/test_tracking_service.py
+++ b/tests/unit/test_tracking_service.py
@@ -10,3 +10,4 @@ async def test_stub_provider_tracks():
     resp = await service.track("123", Courier.STUB)
     assert resp.tracking_number == "123"
     assert resp.courier == Courier.STUB
+    await service.aclose()


### PR DESCRIPTION
## Summary
- refactor Andreani provider to keep a persistent httpx.AsyncClient configured via environment variables
- add close hooks to TrackingService and route dependency to tidy up clients
- update tests for persistent client usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fd0b937888323b6e09e399d30cebb