### PR TITLE
docs: add docstrings for tracking endpoints and services

### DIFF
--- a/app/api/tracking.py
+++ b/app/api/tracking.py
@@ -1,3 +1,5 @@
+"""API routes for shipment tracking and service health checks."""
+
 from fastapi import APIRouter, Depends
 
 from app.services.tracking_service import TrackingService
@@ -6,17 +8,22 @@ from app.data.domain.courier import Courier
 
 
 async def get_tracking_service():
+    """Yield a ``TrackingService`` instance and ensure proper cleanup."""
+
     service = TrackingService()
     try:
         yield service
     finally:
         await service.aclose()
 
+
 router = APIRouter(prefix="/api/v1")
 
 
 @router.get("/health")
 async def health():
+    """Return a simple status response confirming the service is running."""
+
     return {"status": "ok"}
 
 
@@ -26,4 +33,6 @@ async def get_tracking(
     courier: Courier,
     service: TrackingService = Depends(get_tracking_service),
 ):
+    """Fetch tracking details for a shipment from the specified courier."""
+
     return await service.track(tracking_number, courier)

--- a/app/services/providers/stub.py
+++ b/app/services/providers/stub.py
@@ -7,8 +7,14 @@ from .base import Provider
 
 
 class StubProvider(Provider):
+    """Simple provider that returns static tracking data for testing."""
+
     async def track(self, tracking_number: str) -> TrackingResponse:
-        event = TrackingEvent(description="Package received", timestamp=datetime.utcnow())
+        """Return a mock tracking response for ``tracking_number``."""
+
+        event = TrackingEvent(
+            description="Package received", timestamp=datetime.utcnow()
+        )
         return TrackingResponse(
             tracking_number=tracking_number,
             courier=Courier.STUB,

--- a/app/services/tracking_service.py
+++ b/app/services/tracking_service.py
@@ -5,19 +5,27 @@ from app.data.domain.courier import Courier
 
 
 class TrackingService:
-    def __init__(self):
+    """Coordinate tracking lookups across available courier providers."""
+
+    def __init__(self) -> None:
+        """Initialize provider instances for each supported courier."""
+
         self.providers = {
             Courier.STUB: StubProvider(),
             Courier.ANDREANI: AndreaniProvider(),
         }
 
     async def track(self, tracking_number: str, courier: Courier) -> TrackingResponse:
+        """Retrieve tracking information from the provider for ``courier``."""
+
         provider = self.providers.get(courier)
         if not provider:
             raise ValueError("unsupported courier")
         return await provider.track(tracking_number)
 
     async def aclose(self) -> None:
+        """Close any provider clients that expose an asynchronous close method."""
+
         for provider in self.providers.values():
             close = getattr(provider, "aclose", None)
             if close:


### PR DESCRIPTION
## Summary
- document tracking API endpoints
- add class and method docstrings for tracking service
- expand provider docstrings for stub and Andreani implementations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abd4358af08323b893c5deb9eca541